### PR TITLE
Avoid paging when stdout is not a terminal

### DIFF
--- a/cmd/logbook/main.go
+++ b/cmd/logbook/main.go
@@ -208,7 +208,7 @@ func readEntry(file string) {
 		pager = "less"
 	}
 
-	if isTTY() || lines > 20 {
+	if isTTY() && lines > 20 {
 		runCmd(exec.Command(pager, file), "failed to open pager")
 	} else {
 		runCmd(exec.Command("cat", file), "failed to print file")


### PR DESCRIPTION
## Summary
- ensure `logbook read` uses pager only when stdout is a terminal and the file is lengthy

## Testing
- `go vet ./...`
- `go build ./...`


------
https://chatgpt.com/codex/tasks/task_e_68b07369c3d88329a7d9569005eca87d